### PR TITLE
fix: restore main CI (Ruby 4.0 logger dep, lutaml-model main branch)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "canon"
-gem "lutaml-model", github: "lutaml/lutaml-model", branch: "fix/global-context-register-lookup-fallback"
+gem "lutaml-model", github: "lutaml/lutaml-model", branch: "main"
 gem "nokogiri"
 gem "rake"
 gem "rspec"

--- a/unitsdb.gemspec
+++ b/unitsdb.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fuzzy_match"
+  spec.add_dependency "logger"
   spec.add_dependency "lutaml-model", "~> 0.8.0"
   spec.add_dependency "rdf", "~> 3.1"
   spec.add_dependency "rdf-turtle", "~> 3.1"


### PR DESCRIPTION
## Summary

Two unrelated fixes that both block CI on main:

- **`unitsdb.gemspec`**: declare `logger` as a runtime dependency. Ruby 4.0 removed `logger` from default gems, and `rdf` (loaded by `lib/unitsdb/commands/check_si/si_ttl_parser.rb`) requires it without declaring it. Result on Ruby 4.0:
  ```
  LoadError: cannot load such file -- logger
    from rdf-3.3.1/lib/rdf/util/logger.rb:2
  ```
- **`Gemfile`**: repoint `lutaml-model` at `branch: "main"`. The previous `fix/global-context-register-lookup-fallback` branch was deleted upstream after merging, so every `bundle install` on main fails with:
  ```
  Git error: ... Revision fix/global-context-register-lookup-fallback
  does not exist in the repository
  ```

## Why now

The Opal PR (#27) surfaced both — they're not Opal-specific. Main has been silently broken (no CI runs since April 2026) until #27 pushed the first wave of CI against current Ruby heads. Splitting these out keeps #27 focused on Opal compatibility.

## Test plan

- [x] `bundle exec rspec spec/unitsdb/commands/check_si_command_spec.rb` -- 3 examples, 0 failures (Ruby 3.4)
- [x] `bundle install` resolves with `lutaml-model` from `main`
- [ ] CI green on Ruby 4.0 (`rake / Test on Ruby 4.0 ...`)
