### PR TITLE
fix: drop git-source lutaml-model from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "canon"
-gem "lutaml-model", github: "lutaml/lutaml-model", branch: "fix/global-context-register-lookup-fallback"
 gem "nokogiri"
 gem "rake"
 gem "rspec"


### PR DESCRIPTION
## Summary

- Remove `gem "lutaml-model", github: ..., branch: "..."` override from `Gemfile`
- Lets `bundle install` resolve `lutaml-model ~> 0.8.0` (already in `unitsdb.gemspec`) from RubyGems
- Verified: `bundle exec rake spec` → 811 examples, 0 failures; resolves to `lutaml-model 0.8.16`

## Why

A release gem must not carry `gem "X", github: "..."` in its Gemfile: the
release CI workflow (`metanorma/ci/.github/workflows/rubygems-release.yml`)
deletes `Gemfile.lock` and re-resolves dependencies with `bundle install`,
which cannot reliably materialize git-source deps without bundler-specific
workarounds.

`lutaml-model` 0.8.16 is already published on RubyGems, so the override is
unnecessary and the existing gemspec constraint is sufficient.

## Test plan

- [x] `bundle install` resolves cleanly to RubyGems-only deps
- [x] `bundle exec rake spec` passes (811/811)
- [ ] CI on this PR (rake workflow) passes
